### PR TITLE
Fix for newer Test::Builders that use Test2

### DIFF
--- a/lib/App/ForkProve.pm
+++ b/lib/App/ForkProve.pm
@@ -42,14 +42,16 @@ sub run {
         unshift @inc, 'blib/lib', 'blib/arch';
     }
 
+    {
+        local $ENV{TB_NO_EARLY_INIT} = 1;
+        for (@modules) {
+            my($module, @import) = split /[=,]/;
+            local @INC{map pkg_to_file($_), @Blacklists} = (__FILE__) x scalar(@Blacklists);
+            local @INC = (@inc, @INC);
 
-    for (@modules) {
-        my($module, @import) = split /[=,]/;
-        local @INC{map pkg_to_file($_), @Blacklists} = (__FILE__) x scalar(@Blacklists);
-        local @INC = (@inc, @INC);
-
-        eval "require $module" or die $@;
-        $module->import(@import);
+            eval "require $module" or die $@;
+            $module->import(@import);
+        }
     }
 
     for my $loaded (keys %INC) {

--- a/lib/App/ForkProve/SourceHandler.pm
+++ b/lib/App/ForkProve/SourceHandler.pm
@@ -112,8 +112,13 @@ sub _run {
 
     # Test::Builder is loaded? Reset the $Test object to make it unaware
     # that it's a forked off proecess so that subtests won't run
-    if (defined $Test::Builder::Test) {
-        $Test::Builder::Test->reset;
+    if ($INC{'Test/Builder.pm'}) {
+        if (defined $Test::Builder::Test) {
+            $Test::Builder::Test->reset;
+        }
+        else {
+            Test::Builder->new;
+        }
     }
 
     # avoid child processes sharing the same seed value as the parent


### PR DESCRIPTION
This /will/ fix preloading of Test::Builder once I release the
corresponding Test2 fix. Until that release this will cause no harm, so
it can be merged/released whenever.